### PR TITLE
Capitalize AUC helper file and expose new parameters

### DIFF
--- a/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/trajectory_AUC.py
+++ b/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/trajectory_AUC.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -57,6 +58,8 @@ def temporal_auc_from_trajectory_files(
     duration_grid: str | int | None | list[timedelta] = 10000,
     AUC_dist_approx: int = -1,
     seed: int = 0,
+    offset: timedelta = timedelta(0),
+    exclude_history: bool | Sequence[str] = False,
 ) -> pl.DataFrame:
     """Compute temporal AUCs over a collection of trajectory files.
 
@@ -67,6 +70,10 @@ def temporal_auc_from_trajectory_files(
         duration_grid: Duration grid for :func:`temporal_aucs`.
         AUC_dist_approx: Distribution approximation size.
         seed: Random seed for subsampling.
+        offset: Offset from the prediction time at which the evaluation window begins.
+        exclude_history: If ``True`` or an iterable of task names, rows where the subject
+            has a historical instance of the predicate prior to the prediction time
+            are removed for the specified tasks.
 
     Returns:
         A dataframe containing the temporal AUCs for each predicate.
@@ -97,4 +104,6 @@ def temporal_auc_from_trajectory_files(
         duration_grid=duration_grid,
         AUC_dist_approx=AUC_dist_approx,
         seed=seed,
+        offset=offset,
+        exclude_history=exclude_history,
     )

--- a/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/trajectory_AUC.py
+++ b/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/trajectory_AUC.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from datetime import timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from datetime import timedelta
 
 import polars as pl
 from aces.config import PlainPredicateConfig


### PR DESCRIPTION
## Summary
- rename `trajectory_auc.py` to `trajectory_AUC.py` for consistency
- expose `offset` and `exclude_history` parameters in `temporal_auc_from_trajectory_files`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433975c380832cbb549907f7fd88c3