### PR TITLE
Implement random/resolution duration grid modes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "es-aces>=0.7.0",
   "hydra-core",
   "MEDS-transforms~=0.5.0",
-  "flexible_schema"
+  "flexible_schema",
+  "pytimeparse"
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
## Summary
- implement `_parse_resolution`, `_collect_durations`, `resolution_grid` and `random_grid`
- add doctests for grid behaviour including error cases
- delete old pytest-based grid tests
- use `pytimeparse` for resolution parsing

## Testing
- `pre-commit run --files src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py pyproject.toml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843457dee08832c88ae0105d3471c5c