### PR TITLE
Expand AUC property tests and stabilize TTE hypothesis strategies

### DIFF
--- a/tests/test_auc.py
+++ b/tests/test_auc.py
@@ -10,30 +10,32 @@ from tests.helpers import _manual_auc
 
 @st.composite
 def _df_inputs(draw):
-    tasks = draw(st.lists(st.sampled_from(["A", "B", "C"]), min_size=1, max_size=2, unique=True))
-    n_rows = draw(st.integers(min_value=1, max_value=2))
+    tasks = draw(st.lists(st.sampled_from(["A", "B", "C", "D"]), min_size=1, max_size=3, unique=True))
+    n_rows = draw(st.integers(min_value=1, max_value=4))
+    float_strategy = st.floats(min_value=-1_000.0, max_value=1_000.0, allow_nan=False, allow_infinity=False)
     rows = []
     for _ in range(n_rows):
         row = {}
         for task in tasks:
-            true_vals = sorted(
-                draw(
-                    st.lists(
-                        st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
-                        min_size=0,
-                        max_size=3,
-                    )
-                )
-            )
-            false_vals = sorted(
-                draw(
-                    st.lists(
-                        st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
-                        min_size=0,
-                        max_size=3,
-                    )
-                )
-            )
+            true_vals = sorted(draw(st.lists(float_strategy, min_size=0, max_size=5)))
+            false_vals = sorted(draw(st.lists(float_strategy, min_size=0, max_size=5)))
+            row[f"true/{task}"] = true_vals
+            row[f"false/{task}"] = false_vals
+        rows.append(row)
+    return pl.DataFrame(rows), tasks
+
+
+@st.composite
+def _df_unsorted_inputs(draw):
+    tasks = draw(st.lists(st.sampled_from(["A", "B", "C", "D"]), min_size=1, max_size=3, unique=True))
+    n_rows = draw(st.integers(min_value=1, max_value=4))
+    float_strategy = st.floats(min_value=-1_000.0, max_value=1_000.0, allow_nan=False, allow_infinity=False)
+    rows = []
+    for _ in range(n_rows):
+        row = {}
+        for task in tasks:
+            true_vals = draw(st.lists(float_strategy, min_size=0, max_size=5))
+            false_vals = draw(st.lists(float_strategy, min_size=0, max_size=5))
             row[f"true/{task}"] = true_vals
             row[f"false/{task}"] = false_vals
         rows.append(row)
@@ -52,4 +54,15 @@ def test_df_auc_matches_manual(data):
                 assert auc_val is None
             else:
                 assert math.isclose(auc_val, expected, rel_tol=1e-9)
+                assert 0.0 <= auc_val <= 1.0
+
+
+@given(_df_unsorted_inputs())
+def test_df_auc_in_bounds_unsorted(data):
+    df, tasks = data
+    result = df_AUC(df)
+    for row_idx in range(df.height):
+        for task in tasks:
+            auc_val = result[f"AUC/{task}"][row_idx]
+            if auc_val is not None:
                 assert 0.0 <= auc_val <= 1.0

--- a/tests/test_get_ttes.py
+++ b/tests/test_get_ttes.py
@@ -11,7 +11,7 @@ from MEDS_trajectory_evaluation.temporal_AUC_evaluation.get_ttes import get_raw_
 
 
 def _duration_tds(min_days: int, max_days: int) -> st.SearchStrategy[timedelta]:
-    return st.timedeltas(min_value=timedelta(days=min_days), max_value=timedelta(days=max_days))
+    return st.integers(min_value=min_days, max_value=max_days).map(lambda d: timedelta(days=d))
 
 
 @st.composite
@@ -43,7 +43,9 @@ def _raw_inputs(draw):
     index_rows = []
     for s in subjects:
         n_index = draw(st.integers(min_value=1, max_value=2))
-        pred_durations = draw(st.lists(_duration_tds(-2, 10), min_size=n_index, max_size=n_index))
+        pred_durations = draw(
+            st.lists(_duration_tds(-2, 10), min_size=n_index, max_size=n_index, unique=True)
+        )
         for d in sorted(pred_durations):
             index_rows.append({"subject_id": s, "prediction_time": base_time + d})
     index_df = pl.DataFrame(index_rows)


### PR DESCRIPTION
## Summary
- Broaden AUC hypothesis strategies to draw larger value ranges, more tasks/rows, and include an additional unsorted-input test
- Generate whole-day unique prediction times for TTE property tests to avoid flakiness

## Testing
- `pre-commit run --files tests/test_auc.py tests/test_get_ttes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689138e27570832c9b0fbc7fdcf36509