### PR TITLE
Capture tree output when validation fails

### DIFF
--- a/src/MEDS_trajectory_evaluation/ACES_config_evaluation/task_config.py
+++ b/src/MEDS_trajectory_evaluation/ACES_config_evaluation/task_config.py
@@ -1,6 +1,7 @@
 """Utilities to define and manipulate zero-shot labeling task configurations from ACES configurations."""
 
 import copy
+from contextlib import redirect_stdout
 from io import StringIO
 
 from aces.config import TaskExtractorConfig
@@ -43,12 +44,13 @@ def validate_task_cfg(task_cfg: TaskExtractorConfig):
 
     if prediction_time_window_node not in label_window_node.ancestors:
         strio = StringIO()
-        tree_str = print_tree(task_cfg.window_tree, file=strio)
+        with redirect_stdout(strio):
+            print_tree(task_cfg.window_tree)
         raise ValueError(
             "zeroshot_ACES only supports task configs where the prediction time node is an ancestor of the "
             f"label node. Here, the prediction time window node ({prediction_time_window_node.node_name}) "
             f"is not an ancestor of the label window node ({label_window_node.node_name}). Got tree:\n"
-            f"{tree_str.get_value()}"
+            f"{strio.getvalue()}"
         )
 
 

--- a/tests/test_task_config.py
+++ b/tests/test_task_config.py
@@ -1,0 +1,52 @@
+"""Tests for task configuration validation utilities."""
+
+from contextlib import redirect_stdout
+from io import StringIO
+
+import pytest
+from aces.config import EventConfig, PlainPredicateConfig, TaskExtractorConfig, WindowConfig
+from bigtree import print_tree
+
+from MEDS_trajectory_evaluation.ACES_config_evaluation.task_config import validate_task_cfg
+
+
+def test_validate_task_cfg_error_includes_tree_when_prediction_not_ancestor():
+    """Ensures the validation error message contains the window tree when misconfigured."""
+
+    task_cfg = TaskExtractorConfig(
+        predicates={
+            "trigger_pred": PlainPredicateConfig("TRIGGER"),
+            "label_pred": PlainPredicateConfig("LABEL"),
+        },
+        trigger=EventConfig("trigger_pred"),
+        windows={
+            "prediction": WindowConfig(
+                start="trigger + 1h",
+                end="start + 1h",
+                start_inclusive=True,
+                end_inclusive=True,
+                has={},
+                index_timestamp="start",
+            ),
+            "label": WindowConfig(
+                start="end - 1h",
+                end="trigger + 4h",
+                start_inclusive=False,
+                end_inclusive=True,
+                has={},
+                label="label_pred",
+            ),
+        },
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        validate_task_cfg(task_cfg)
+
+    strio = StringIO()
+    with redirect_stdout(strio):
+        print_tree(task_cfg.window_tree)
+    tree_str = strio.getvalue()
+
+    message = str(excinfo.value)
+    assert "prediction time window node (prediction.start)" in message
+    assert tree_str in message


### PR DESCRIPTION
## Summary
- capture the ACES window tree output with a redirected StringIO buffer when validation fails
- include the captured tree in the ValueError message
- add a regression test that verifies the tree appears in the error message when the prediction node is not an ancestor of the label node

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc05020934832c828f095c75e9839f