### PR TITLE
Bump MEDS ecosystem dep pins (MEDS-transforms 0.5 → 0.6.7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "meds~=0.4.0",
-  "es-aces>=0.7.0",
-  "hydra-core",
-  "MEDS-transforms~=0.5.0",
-  "flexible_schema",
-  "pytimeparse"
+  "meds~=0.4.1",
+  "es-aces>=0.7.3",
+  "hydra-core~=1.3.2",
+  "MEDS-transforms>=0.6.7,<0.7",
+  "flexible_schema>=0.1.1",
+  "pytimeparse",
 ]
 
 [dependency-groups]

--- a/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py
+++ b/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py
@@ -185,21 +185,29 @@ def df_AUC(df: pl.DataFrame) -> pl.DataFrame:
     ids = [c for c in df.columns if c.split("/")[0] not in {"true", "false"}]
 
     structs = [
-        pl.struct(true=pl.col(f"true/{t}"), false=pl.col(f"false/{t}")).alias(f"dist/{t}") for t in tasks
+        pl.struct(
+            true=pl.col(f"true/{t}").cast(pl.List(pl.Float64)),
+            false=pl.col(f"false/{t}").cast(pl.List(pl.Float64)),
+        ).alias(f"dist/{t}")
+        for t in tasks
     ]
 
     df = df.select(*ids, *structs).with_row_index("__idx")
 
     dists = cs.starts_with("dist/")
-    T = dists.struct.field("true")
-    F = dists.struct.field("false")
+    # polars 1.31+ drops the parent selector name when applying `.struct.field(...)`; `.name.keep()`
+    # restores the "dist/<task>" name so downstream `.name.map(_reprefix_fntr("AUC"))` can find it.
+    T = dists.struct.field("true").name.keep()
+    F = dists.struct.field("false").name.keep()
 
     num_pairs = T.list.len() * F.list.len()
     num_F_lt_T_pairs = F.list.explode().search_sorted(T.list.explode(), side="left").sum().over("__idx")
     num_F_lte_T_pairs = F.list.explode().search_sorted(T.list.explode(), side="right").sum().over("__idx")
 
     AUC = ((num_F_lt_T_pairs + num_F_lte_T_pairs) / 2) / num_pairs
-    AUC = pl.when(AUC.is_infinite() | AUC.is_nan()).then(None).otherwise(AUC)
+    # polars 1.31+ derives the output name from the first `then(None)`, losing the AUC column name;
+    # putting AUC in `then` preserves name inheritance into the subsequent `.name.map(...)`.
+    AUC = pl.when(AUC.is_finite()).then(AUC).otherwise(None)
 
     return df.select(*ids, AUC.name.map(_reprefix_fntr("AUC")))
 
@@ -359,8 +367,8 @@ def random_grid(ttes_df: pl.DataFrame, n: int | None) -> pl.Series:
         shape: (3,)
         Series: 'tte/A' [duration[μs]]
         [
+            1d
             2d
-            3d
             5d
         ]
         >>> random_grid(pl.DataFrame({"x": [1]}), None)
@@ -571,6 +579,9 @@ def add_labels_from_true_tte(
                 # Insufficient follow-up (censored cases)
                 None
             )
+            # polars 1.31+ names `when(...).then(...).otherwise(None)` as "literal"; `.name.keep()`
+            # restores the "tte/<task>" name from the selector root before the prefix rewrite.
+            .name.keep()
             .name.map(_reprefix_fntr("label"))
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -156,7 +156,7 @@ wheels = [
 
 [[package]]
 name = "es-aces"
-version = "0.7.1"
+version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bigtree" },
@@ -169,9 +169,9 @@ dependencies = [
     { name = "pytimeparse" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/dc/7489862571550f7d410faf3aa297c555bbca99965f1de1699daa2a7ec423/es_aces-0.7.1.tar.gz", hash = "sha256:4d9d1fcc3f168c62fe546d8cc86400c0fb51e5835bc63a116ce1148c174e7d73", size = 2588599, upload-time = "2025-06-06T16:48:59.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/25/c434866e9de99bb9560d435e4db8137592b5f68f6c58780fd7e5e5befaaf/es_aces-0.7.3.tar.gz", hash = "sha256:180099dda1a35737245804253a62f81dd93f575159e04da539b464b3b1527d2f", size = 2654607, upload-time = "2026-04-21T21:19:51.049Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/96/dbe12850e42558e310a643ffcded610f4f558446e3d9dc1074d273d0462c/es_aces-0.7.1-py3-none-any.whl", hash = "sha256:e15da03dfe0b463e915554dcf6eb505d401ce7c198dc35fe857fcd2faccdca6d", size = 61819, upload-time = "2025-06-06T16:48:57.368Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b1/6e2dbec4ec004c30500fd83865101b083f9449c0310e6ddc5579a9a529c0/es_aces-0.7.3-py3-none-any.whl", hash = "sha256:4bd48c5558379a8b3c22c6b600f1c3e1582ef465b3ad8f0f72a6ce4b12f244d7", size = 61766, upload-time = "2026-04-21T21:19:49.505Z" },
 ]
 
 [[package]]
@@ -185,16 +185,16 @@ wheels = [
 
 [[package]]
 name = "flexible-schema"
-version = "0.1"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "pyarrow" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/78/ee673ccc111be2152661e6ab76751d51fca2bcea3e45a353c89921c4d1bc/flexible_schema-0.1.tar.gz", hash = "sha256:7f542a767e678bfe4dbf23c62a1380c3378a9e311dfa21bbcedbd4b76f3096bc", size = 33782, upload-time = "2025-04-15T17:59:46.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/da/a1e2540ee68bfebf849b810e12d5d3826f744fad9f5e134e9a533fed22eb/flexible_schema-0.1.1.tar.gz", hash = "sha256:adc8d051c66cab960fc3a9440b44a54eda5d62fe1e59818737adc663fb1d75f5", size = 34747, upload-time = "2025-11-05T17:13:50.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/59/1f50a3c7f2d32c513e7f29bcd5c4998f9ac73812160b7f937c6ad45839b7/flexible_schema-0.1-py3-none-any.whl", hash = "sha256:71177c1b5fb3f934c8580a2668493512dbd9b70984b828ba9570eb1201fd0788", size = 22907, upload-time = "2025-04-15T17:54:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b4/c8a0fa542aa7134ad5e0b55e2c18b6de457103f13d04ec63ee62ae35c9c5/flexible_schema-0.1.1-py3-none-any.whl", hash = "sha256:6ab3a35ce4e518897f142c82470933ea7bfb6a9abc0220e58638b67b16c51f67", size = 23402, upload-time = "2025-11-05T17:13:48.561Z" },
 ]
 
 [[package]]
@@ -280,7 +280,7 @@ wheels = [
 
 [[package]]
 name = "meds"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flexible-schema" },
@@ -288,9 +288,9 @@ dependencies = [
     { name = "pyarrow" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/f3/c99769ba2e36d67e015190733a03689dffa64139b93006277a4e3abdd034/meds-0.4.0.tar.gz", hash = "sha256:8f0c9ed8334a57eb8e93beefa7c1c5003490d9c647691fb740be4fa3919e8ec3", size = 376216, upload-time = "2025-05-03T05:40:49.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/2a/6949d9da216fcc9df2f44dd3d3c10b8dbc6b41c069ec129ca23184cd76fd/meds-0.4.1.tar.gz", hash = "sha256:b6c77f84e32ad49e6065140992396064a8a7bbb1e68440448e53c7e66f3f8f2c", size = 386332, upload-time = "2025-11-05T17:15:04.8Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/de/845251288337b576f10b13c3fed6f0cbbdd02bb3aae07145109f689d5561/meds-0.4.0-py3-none-any.whl", hash = "sha256:7201393a607aac5c4e71c3543ff54c46cf2e83f7a6e5875d6bfc0104f7dc7ebd", size = 20529, upload-time = "2025-05-03T05:40:47.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4c/2c40e3ba53504728d6895bba26d69c165757424cfa79ce2bc20679cbb0b0/meds-0.4.1-py3-none-any.whl", hash = "sha256:3a83e2410d720da10d133fd6920180a249e063565edbe41f78ac1c5e75c42b6b", size = 20695, upload-time = "2025-11-05T17:15:03.105Z" },
 ]
 
 [[package]]
@@ -337,11 +337,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "es-aces", specifier = ">=0.7.0" },
-    { name = "flexible-schema" },
-    { name = "hydra-core" },
-    { name = "meds", specifier = "~=0.4.0" },
-    { name = "meds-transforms", specifier = "~=0.5.0" },
+    { name = "es-aces", specifier = ">=0.7.3" },
+    { name = "flexible-schema", specifier = ">=0.1.1" },
+    { name = "hydra-core", specifier = "~=1.3.2" },
+    { name = "meds", specifier = "~=0.4.1" },
+    { name = "meds-transforms", specifier = ">=0.6.7,<0.7" },
     { name = "pytimeparse" },
 ]
 
@@ -358,7 +358,7 @@ dev = [
 
 [[package]]
 name = "meds-transforms"
-version = "0.5.3"
+version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -370,10 +370,11 @@ dependencies = [
     { name = "pretty-print-directory" },
     { name = "pyarrow" },
     { name = "pytest" },
+    { name = "yaml-to-disk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/52/e9bc9ece29db1d9bd0b7a9c3d581557b529cad0ebabbc55bb1a1365ae9db/meds_transforms-0.5.3.tar.gz", hash = "sha256:832f607b60ae81f919beee6b200e4cb7259781f08536766853ef06fe55948ed6", size = 332567, upload-time = "2025-06-06T20:08:03.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/19/407efdafc8adbb8385495579934d88fdf8c5c8373fc2e76026fe0b54e26d/meds_transforms-0.6.7.tar.gz", hash = "sha256:8c957a5743d7e53b2262d3898356feb7c2ebcb3236b5b10156ef5c44c2774149", size = 589647, upload-time = "2026-04-18T14:45:25.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/01/7522f825fd26e82fbc394be44718a16925d6983ca8481a08bbf74f8c67fd/meds_transforms-0.5.3-py3-none-any.whl", hash = "sha256:bb8e4cb65470d669de99bea813c64ec9c46d3b8b749fd0445f0261da46f2912d", size = 200632, upload-time = "2025-06-06T20:08:01.669Z" },
+    { url = "https://files.pythonhosted.org/packages/40/19/55d217de368c7fb643f89f7ef312092740c24c189f75ec28d7c68b0b1dbd/meds_transforms-0.6.7-py3-none-any.whl", hash = "sha256:ce4b458f9e26e31a3e1fe7000769bb7be5b3bf58c3ba0da071d639a6a4a013c0", size = 219935, upload-time = "2026-04-18T14:45:23.714Z" },
 ]
 
 [[package]]
@@ -460,16 +461,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.30.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/b6/8dbdf626c0705a57f052708c9fc0860ffc2aa97955930d5faaf6a66fcfd3/polars-1.30.0.tar.gz", hash = "sha256:dfe94ae84a5efd9ba74e616e3e125b24ca155494a931890a8f17480737c4db45", size = 4668318, upload-time = "2025-05-21T13:33:24.175Z" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/1b/eea7d6fe6daafc1d784cc0f76c729b28051837ccb2d51ae64a0a3f798142/polars-1.40.0.tar.gz", hash = "sha256:711dd50dcbc35ba42a2625fcadc2a1349e2e9abf48e35631bdabafb90d89874b", size = 732943, upload-time = "2026-04-18T05:25:26.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/48/e9b2cb379abcc9f7aff2e701098fcdb9fe6d85dc4ad4cec7b35d39c70951/polars-1.30.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4c33bc97c29b7112f0e689a2f8a33143973a3ff466c70b25c7fd1880225de6dd", size = 35704342, upload-time = "2025-05-21T13:32:22.996Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ca/f545f61282f75eea4dfde4db2944963dcd59abd50c20e33a1c894da44dad/polars-1.30.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e3d05914c364b8e39a5b10dcf97e84d76e516b3b1693880bf189a93aab3ca00d", size = 32459857, upload-time = "2025-05-21T13:32:27.728Z" },
-    { url = "https://files.pythonhosted.org/packages/76/20/e018cd87d7cb6f8684355f31f4e193222455a6e8f7b942f4a2934f5969c7/polars-1.30.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a52af3862082b868c1febeae650af8ae8a2105d2cb28f0449179a7b44f54ccf", size = 36267243, upload-time = "2025-05-21T13:32:31.796Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e7/b88b973021be07b13d91b9301cc14392c994225ef5107a32a8ffd3fd6424/polars-1.30.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:ffb3ef133454275d4254442257c5f71dd6e393ce365c97997dadeb6fa9d6d4b5", size = 33416871, upload-time = "2025-05-21T13:32:35.077Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/7c/d46d4381adeac537b8520b653dc30cb8b7edbf59883d71fbb989e9005de1/polars-1.30.0-cp39-abi3-win_amd64.whl", hash = "sha256:c26b633a9bd530c5fc09d317fca3bb3e16c772bd7df7549a9d8ec1934773cc5d", size = 36363630, upload-time = "2025-05-21T13:32:38.286Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/b5/5056d0c12aadb57390d0627492bef8b1abf3549474abb9ae0fd4e2bfa885/polars-1.30.0-cp39-abi3-win_arm64.whl", hash = "sha256:476f1bde65bc7b4d9f80af370645c2981b5798d67c151055e58534e89e96f2a8", size = 32643590, upload-time = "2025-05-21T13:32:42.107Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ad/d5ed79269b7fe59a3dbbfbdbecbe1e59a0b56e38d36491e57d2bfb5846c1/polars-1.40.0-py3-none-any.whl", hash = "sha256:60b1d677ca363e2fc6fdea8c3d16c0653fd52cc37f0249e0f29d9536d5aa45ef", size = 828012, upload-time = "2026-04-18T05:23:39.055Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/b2/eae6c1b3d16c7a64ff382f557985ff939cce13455e8c9d056ab8e1e0fc87/polars_runtime_32-1.40.0.tar.gz", hash = "sha256:e31bff8bd37492c714e155e2e1429ac2d9ddf2dd6ec6474cc1cc70ac0b2bd6af", size = 2935285, upload-time = "2026-04-18T05:25:28.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/e4/2325689d2af4f9e70699ff98e8a2543707bebc34af78a5fe0e654107d9ed/polars_runtime_32-1.40.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:cab3ac7ff5bc9e0f4b3b146015569e9417cf0eaff8d3fb71004d73d67b6f09c7", size = 52092528, upload-time = "2026-04-18T05:23:42.341Z" },
+    { url = "https://files.pythonhosted.org/packages/19/a6/82157b19c5c40b2c1ed0493b87b9eaf9b4863cdedca5575ee083488b45ba/polars_runtime_32-1.40.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d29624c75c4049253300786d00882fce620b3677ce495ebc4199292de8c2ba02", size = 46365073, upload-time = "2026-04-18T05:23:46.7Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b5/5c4f1f2545f56c664cc57bbdd1aa66fcfcb129aa137ed72cc81d58eb480f/polars_runtime_32-1.40.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a034dc0d8481fc1ca0456ab33e98e53a4c6d6cc6a2edb36246cc81c936b925dc", size = 50250561, upload-time = "2026-04-18T05:23:51.316Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/51/cb5eb75394f39c0ec14fddcc9b11adb707e1f28224a552ecbfa72d39b61b/polars_runtime_32-1.40.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70e78c2f13a54a9d92ae30d2625bda759173cc4867ad6a39f85f140058d899c6", size = 56243695, upload-time = "2026-04-18T05:23:55.932Z" },
+    { url = "https://files.pythonhosted.org/packages/16/3a/be1437c0fbecbb07d81b151456089c3cf054eea5a791f849ed39b67611ca/polars_runtime_32-1.40.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1843272c0ef49f4a07435888f0059eca08ec16ab9880219c457195a081df0281", size = 50427843, upload-time = "2026-04-18T05:24:00.159Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c7/ea6449a2161816a13ed1d8aa02177d5a0594e011f0df5ddd2fad8e5bf20e/polars_runtime_32-1.40.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:081237dba07f15d61fc151825f203165480e9503ebe72a474a8c99aa78021962", size = 54153077, upload-time = "2026-04-18T05:24:05.066Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1a/0b239138afe8b80a1a0b4c95db3884e6afbbe82ec3318918ab03bc57f231/polars_runtime_32-1.40.0-cp310-abi3-win_amd64.whl", hash = "sha256:a916040e0b7f461ce987e4551fed9eea5914b4fbb5af907b1d9e80db71fadeb5", size = 51822748, upload-time = "2026-04-18T05:24:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ce/c16ef8fd3030b7342032b040fab21a42f6fee57e47ee7f41e2f1a1e36f01/polars_runtime_32-1.40.0-cp310-abi3-win_arm64.whl", hash = "sha256:719c64eecde24a95aa3599eb9c8efc98c1499bab7ef9c01cbbe8939cd583e654", size = 45819617, upload-time = "2026-04-18T05:24:13.214Z" },
 ]
 
 [[package]]
@@ -1031,4 +1046,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
+]
+
+[[package]]
+name = "yaml-to-disk"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/f0/fc5fb39b2800b639e927d847fecc23bc120170d2593d248aca89ab94d512/yaml_to_disk-0.0.4.tar.gz", hash = "sha256:58c707afdc65b2398a4a0a3564f1bc44be8a906e9cb6eb9a588a465413964426", size = 22763, upload-time = "2026-04-10T23:02:13.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/f9/a593dcac68bd8769dc65025562ec88a6b92e7d65cc8f6c275bfc46c58d47/yaml_to_disk-0.0.4-py3-none-any.whl", hash = "sha256:0dc5a541327733c605067bfabe9da51239837243ef213a97b82da1ac8d16fbd2", size = 19751, upload-time = "2026-04-10T23:02:11.984Z" },
 ]


### PR DESCRIPTION
## Summary

- Bumps the MEDS ecosystem pins in `pyproject.toml` toward latest releases (primary target: `MEDS-transforms>=0.6.7,<0.7`, matching the downstream ask in #26).
- Adds floors for previously-unpinned deps (`flexible_schema`, `hydra-core`).
- Includes small `temporal_AUCS.py` adapter changes required by polars 1.40 (pulled in transitively via `MEDS-transforms 0.6.7` and `es-aces 0.7.3`).

Closes #26. Refs #27.

## What changed

### `pyproject.toml`

```diff
 dependencies = [
-  "meds~=0.4.0",
-  "es-aces>=0.7.0",
-  "hydra-core",
-  "MEDS-transforms~=0.5.0",
-  "flexible_schema",
-  "pytimeparse"
+  "meds~=0.4.1",
+  "es-aces>=0.7.3",
+  "hydra-core~=1.3.2",
+  "MEDS-transforms>=0.6.7,<0.7",
+  "flexible_schema>=0.1.1",
+  "pytimeparse",
 ]
```

### `src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py`

polars 1.31+ (pulled in via the bumped deps) changed two name-inheritance behaviors that broke three `.name.map(_reprefix_fntr(...))` call sites, and 1.40 tightened `search_sorted` on `list[null]`. The commit adapts:

| Location | Symptom | Fix |
|---|---|---|
| `df_AUC`: `dists.struct.field("true"/"false")` | `struct.field(...)` on a selector now drops the parent "dist/<task>" name, leaving just "true" / "false". `_reprefix_fntr` rejected single-token names. | Add `.name.keep()` after `struct.field(...)` to restore the selector-derived column name. |
| `df_AUC`: `pl.when(...).then(None).otherwise(AUC)` | polars names the output "literal" from the `None` branch instead of inheriting from `otherwise`. | Flip branches: `pl.when(AUC.is_finite()).then(AUC).otherwise(None)` preserves the name from `then`. |
| `df_AUC`: empty-list handling | polars 1.40's `search_sorted` rejects `list[null]` dtype — tripped by hypothesis-generated all-empty-list inputs. | Cast `pl.col("true/<t>")` / `pl.col("false/<t>")` to `List(Float64)` when building `dist/<t>` structs, so empty distributions have a concrete dtype. |
| `add_labels_from_true_tte` (censoring branch) | `pl.when(...).then(True)…when(...).then(False).otherwise(None)` loses the `tte/<task>` name. | Add `.name.keep()` before `.name.map(_reprefix_fntr("label"))`. |
| `random_grid` doctest | polars' seeded `Series.sample` output changed between 1.30 → 1.40 (`[2d,3d,5d]` → `[1d,2d,5d]`). | Update the expected output in the doctest. |

All 46 tests (doctests + hypothesis property tests) pass locally with the new lock.

## Status (2026-04-21)

- ✅ `meds-evaluation 0.0.6` released with relaxed polars (`>=0.20.8`). Not a direct dep of this branch, but unblocks the separate `ZSACES_aggregate` work in #4.
- ✅ `es-aces 0.7.3` released 2026-04-21 with a polars pin compatible with `MEDS-transforms 0.6.7`.
- ✅ `uv lock` resolves cleanly on this branch.
- ✅ Full test suite passes.
- ⏳ Waiting on CI green on this PR.

## Safety check for our own code

The only `MEDS-transforms` symbol we consume is `map_over`, imported at
`src/MEDS_trajectory_evaluation/ACES_config_evaluation/__main__.py:23`.
Its signature is unchanged between 0.5.3 and 0.6.7 (verified against the release
tags), so no call-site refactor was needed for that API.

## Test plan

- [x] `meds-evaluation 0.0.6` + `es-aces 0.7.3` on PyPI
- [x] `uv lock` resolves cleanly
- [x] `uv run pytest -q` passes locally (46 passed)
- [ ] CI green on this PR
- [ ] Dependabot alerts on `pytest` / `Pygments` / `virtualenv` / `filelock` drop after merge