### PR TITLE
Failing regression test for #32 (merge_pred_ttes positional alignment)

### DIFF
--- a/tests/test_temporal_workflow.py
+++ b/tests/test_temporal_workflow.py
@@ -15,7 +15,142 @@ from MEDS_trajectory_evaluation.temporal_AUC_evaluation.get_ttes import (
 from MEDS_trajectory_evaluation.temporal_AUC_evaluation.temporal_AUCS import (
     temporal_aucs,
 )
+from MEDS_trajectory_evaluation.temporal_AUC_evaluation.trajectory_AUC import (
+    temporal_auc_from_trajectory_files,
+)
 from tests.helpers import _manual_auc
+
+
+def test_merge_pred_ttes_aligns_by_subject_not_position():
+    """Regression test for https://github.com/mmcdermott/MEDS_trajectory_evaluation/issues/32.
+
+    `merge_pred_ttes` uses `pl.concat(how="horizontal")` after dropping the id columns —
+    so it aligns rows positionally. The id columns are taken from the *first* dataframe
+    only. Any per-trajectory dataframe whose (subject_id, prediction_time) ordering differs
+    from the first will silently scramble TTE values across subjects.
+
+    This is the realistic case for `temporal_auc_from_trajectory_files`: each trajectory
+    parquet is independently sampled, and per-file row order is whatever the upstream
+    sampler chose. There is no guarantee orderings match.
+    """
+
+    base = datetime(2022, 1, 1, tzinfo=UTC)
+    pt1 = base
+    pt2 = base + timedelta(days=10)
+
+    # Trajectory 1: subjects in order [1, 2]
+    traj_1 = pl.DataFrame(
+        {
+            "subject_id": [1, 2],
+            "prediction_time": [pt1, pt2],
+            "tte/A": [timedelta(days=5), timedelta(days=10)],
+        }
+    )
+    # Trajectory 2: SAME subjects, same prediction times — different row order [2, 1].
+    # In a real pipeline this happens whenever the sampler streams trajectories in a
+    # different per-file order (parallel workers, shuffled batches, etc.).
+    traj_2 = pl.DataFrame(
+        {
+            "subject_id": [2, 1],
+            "prediction_time": [pt2, pt1],
+            "tte/A": [timedelta(days=99), timedelta(days=30)],
+        }
+    )
+
+    merged = merge_pred_ttes([traj_1, traj_2])
+    by_subject = dict(zip(merged["subject_id"].to_list(), merged["tte/A"].to_list(), strict=True))
+
+    # Subject 1's predicted TTEs across the two trajectories are 5d (from traj_1) and 30d
+    # (from traj_2), in some order. Subject 2's are 10d and 99d. The exact list order
+    # within each subject's cell is unspecified, but the *set* must match.
+    assert set(by_subject[1]) == {timedelta(days=5), timedelta(days=30)}, (
+        "merge_pred_ttes mis-attributed subject 1's TTEs (#32 — positional concat)"
+    )
+    assert set(by_subject[2]) == {timedelta(days=10), timedelta(days=99)}, (
+        "merge_pred_ttes mis-attributed subject 2's TTEs (#32 — positional concat)"
+    )
+
+
+def test_temporal_auc_from_trajectory_files_handles_unordered_parquets(tmp_path):
+    """End-to-end regression test for #32 via `temporal_auc_from_trajectory_files`.
+
+    Two trajectory parquets are written for the same (subject, prediction_time) pairs, but with different row
+    orderings — the realistic case where each trajectory file came from an independent sampling pass. The
+    misalignment causes downstream AUCs to silently differ from a pipeline that simply happened to keep the
+    orderings aligned.
+    """
+
+    base = datetime(2022, 1, 1, tzinfo=UTC)
+    subjects = [1, 2, 3, 4]
+    pred_times = {s: base + timedelta(days=s) for s in subjects}
+
+    # Ground-truth MEDS: each subject has one event_A at a unique day after their pred_time
+    true_offsets = {1: 4, 2: 8, 3: 12, 4: 16}
+    MEDS_df = pl.DataFrame(
+        {
+            "subject_id": subjects,
+            "time": [pred_times[s] + timedelta(days=true_offsets[s]) for s in subjects],
+            "code": ["event_A"] * len(subjects),
+        }
+    )
+
+    # Helper to build a trajectory dataframe with a given subject ordering.
+    def build_traj_df(ordering: list[int], pred_offsets: dict[int, int]) -> pl.DataFrame:
+        rows = []
+        for s in ordering:
+            # Dummy row to anchor the (subject_id, prediction_time) group.
+            rows.append(
+                {"subject_id": s, "prediction_time": pred_times[s], "time": pred_times[s], "code": "DUMMY"}
+            )
+            rows.append(
+                {
+                    "subject_id": s,
+                    "prediction_time": pred_times[s],
+                    "time": pred_times[s] + timedelta(days=pred_offsets[s]),
+                    "code": "event_A",
+                }
+            )
+        return pl.DataFrame(rows)
+
+    # Two trajectories. The per-subject offsets differ, so positional misalignment
+    # produces visibly different downstream AUCs.
+    # traj_a, in subject order [1,2,3,4], assigns near-perfect predictions.
+    traj_a = build_traj_df([1, 2, 3, 4], {1: 3, 2: 7, 3: 11, 4: 15})
+    # traj_b is in REVERSE subject order [4,3,2,1] but assigns predictions that, when
+    # aligned correctly by subject, are also near-perfect. If `merge_pred_ttes` aligns
+    # positionally instead, subject 1 gets traj_b's *subject 4* TTE (and vice-versa).
+    traj_b = build_traj_df([4, 3, 2, 1], {1: 5, 2: 9, 3: 13, 4: 17})
+
+    (tmp_path / "traj_a.parquet").write_bytes(b"")  # ensure dir exists
+    traj_a.write_parquet(tmp_path / "traj_a.parquet")
+    traj_b.write_parquet(tmp_path / "traj_b.parquet")
+
+    predicates = {"A": PlainPredicateConfig(code="event_A")}
+
+    # Compute AUCs through the public entry point.
+    actual = temporal_auc_from_trajectory_files(
+        MEDS_df,
+        tmp_path,
+        predicates,
+        duration_grid=[timedelta(days=10)],
+    )
+
+    # Correct (subject-aligned) predicted probabilities at duration=10d:
+    #   subj 1: traj_a=3d in, traj_b=5d in  -> prob 1.0
+    #   subj 2: traj_a=7d in, traj_b=9d in  -> prob 1.0
+    #   subj 3: traj_a=11d not, traj_b=13d not -> prob 0.0
+    #   subj 4: traj_a=15d not, traj_b=17d not -> prob 0.0
+    # Labels at 10d: subj 1 True, subj 2 True, subj 3 False, subj 4 False
+    # Positives [1.0, 1.0], Negatives [0.0, 0.0]  ->  AUC = 1.0
+    #
+    # If positional concat scrambles traj_b's TTEs, subject 1 gets traj_b's
+    # subject-4 prediction (17d) and subject 4 gets traj_b's subject-1 prediction (5d).
+    # That puts subject 4 (a negative) at higher predicted probability than subject 1
+    # (a positive) → AUC drops below 1.0.
+    assert actual["AUC/A"][0] == 1.0, (
+        "AUC mismatch indicates trajectory rows were mis-attributed across subjects "
+        "by `merge_pred_ttes` (#32). Actual: " + str(actual["AUC/A"][0])
+    )
 
 
 def _duration_tds(min_days: int, max_days: int) -> st.SearchStrategy[timedelta]:

--- a/tests/test_temporal_workflow.py
+++ b/tests/test_temporal_workflow.py
@@ -33,7 +33,6 @@ def test_merge_pred_ttes_aligns_by_subject_not_position():
     parquet is independently sampled, and per-file row order is whatever the upstream
     sampler chose. There is no guarantee orderings match.
     """
-
     base = datetime(2022, 1, 1, tzinfo=UTC)
     pt1 = base
     pt2 = base + timedelta(days=10)
@@ -79,7 +78,6 @@ def test_temporal_auc_from_trajectory_files_handles_unordered_parquets(tmp_path)
     misalignment causes downstream AUCs to silently differ from a pipeline that simply happened to keep the
     orderings aligned.
     """
-
     base = datetime(2022, 1, 1, tzinfo=UTC)
     subjects = [1, 2, 3, 4]
     pred_times = {s: base + timedelta(days=s) for s in subjects}


### PR DESCRIPTION
## Summary

Adds two failing regression tests for #32:

1. **Direct unit test** of `merge_pred_ttes` — two trajectory dataframes for the same subjects in opposite row orderings. After the merge, subject 1's TTE list contains values that came from subject 2's row in trajectory 2.
2. **End-to-end test** through `temporal_auc_from_trajectory_files` — two trajectory parquets are written in opposite subject orderings. With correct subject-aligned merging the AUC at the chosen horizon is 1.0; with the buggy positional concat the AUC collapses to 0.5.

Neither test mocks anything: real `pl.read_parquet` reads, real `get_trajectory_tte`, real `temporal_aucs`. The end-to-end test exercises the public entry point exactly as `MEDS_EIC_AR` and similar downstreams use it.

This is a **draft / do-not-merge-yet** PR — CI is intentionally red. Merging is gated on landing the fix for #32.

## Test plan

- [x] Tests fail on `dev` HEAD (verified locally: direct test sees set mismatch; end-to-end sees AUC drop 1.0 → 0.5)
- [ ] Tests pass after the fix for #32 lands

Refs #32