### PR TITLE
chore: pin all actions, pre-commit hooks, mdformat plugins, and dev deps

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -12,12 +12,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6.2.0
       with:
         python-version: "${{ inputs.python-version }}"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         enable-cache: true
         cache-suffix: "py${{ inputs.python-version }}"

--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package
         uses: ./.github/actions/setup

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package
         uses: ./.github/actions/setup
@@ -23,7 +23,7 @@ jobs:
 
       - name: Find modified files
         id: file_changes
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.6
 
       - name: List all changed files
         run: echo '${{ steps.file_changes.outputs.all_changed_files }}'

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -24,7 +24,7 @@ jobs:
         run: uv build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: python-package-distributions
           path: dist/
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: python-package-distributions
           path: dist/
@@ -65,13 +65,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup package ${{ matrix.python-version }}
         uses: ./.github/actions/setup
@@ -31,6 +31,7 @@ jobs:
           --ignore="benchmark" --ignore="src/meds_torchdata/extensions"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: "docs/index.md"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       # list of supported hooks: https://pre-commit.com/hooks.html
       - id: trailing-whitespace
@@ -22,7 +22,7 @@ repos:
 
   # python code formatting, linting, and import sorting using ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.5
+    rev: 6fec9b7edb08fd9989088709d864a7826dc74e80 # frozen: v0.15.12
     hooks:
       # Run the formatter
       - id: ruff-format
@@ -31,15 +31,15 @@ repos:
         args: ["--fix", "--exit-non-zero-on-fix"]
 
   # python docstring formatting
-  - repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+  - repo: https://github.com/PyCQA/docformatter
+    rev: 0032269a0e65c068af9cd86c9a8859a0ddd568d6 # frozen: v1.7.8
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=110, --wrap-descriptions=110]
 
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types: [yaml]
@@ -47,30 +47,32 @@ repos:
 
   # shell scripts linter
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: 745eface02aef23e168a8afb6b5737818efbea95 # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
 
   # md formatting
+  # mdformat is pinned to 0.7.22 — `mdformat-tables==1.0.0` requires `mdformat<0.8.0`,
+  # so the plugin set determines the upper bound here, not the latest mdformat release.
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.22
+    rev: 83dc2ce5ca115d3390b9b5561d2898366faf0742 # frozen: 0.7.22
     hooks:
       - id: mdformat
         args: ["--number"]
         additional_dependencies:
-          - mdformat-ruff
-          - mdformat-gfm
-          - mdformat-gfm-alerts
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-black
-          - mdformat-config
-          - mdformat-mkdocs
-          - mdformat-toc
+          - mdformat-ruff==0.1.3
+          - mdformat-gfm==1.0.0
+          - mdformat-gfm-alerts==2.0.0
+          - mdformat-tables==1.0.0
+          - mdformat-frontmatter==2.0.10
+          - mdformat-black==0.1.1
+          - mdformat-config==0.2.1
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.5.0
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a # frozen: v2.4.2
     hooks:
       - id: codespell
         args:
@@ -79,13 +81,13 @@ repos:
 
   # jupyter notebook cell output clearing
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.1
+    rev: f5da19ce3b7b40e97c12ee9cd8ce97f48f97ddf7 # frozen: 0.9.1
     hooks:
       - id: nbstripout
 
   # jupyter notebook linting with ruff
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.9.1
+    rev: f96ec7f3b26a32619435686eb5813235f7e3327e # frozen: 1.9.1
     hooks:
       - id: nbqa-ruff
         args: ["--fix"]

--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,6 @@ from omegaconf import DictConfig, OmegaConf
 @pytest.fixture
 def sample_task_schema() -> pl.DataFrame:
     """A fixture that provides sample trajectories for testing."""
-
     return pl.DataFrame(
         {
             "subject_id": [1, 1, 2],
@@ -68,7 +67,6 @@ def sample_labeled_trajectories(
     The structure of the labels by relaxation is that for any set of relaxation options, the label is given by
     the largest dictionary key set that is a subset of the query set of relaxations.
     """
-
     return {
         (1, datetime(1993, 1, 1, tzinfo=UTC)): [
             LabeledTrajectory(
@@ -220,7 +218,6 @@ def sample_labeled_trajectories_on_disk(
 @pytest.fixture
 def sample_task_criteria_cfg() -> DictConfig:
     """A sample task definition."""
-
     return DictConfig(
         {
             "predicates": {
@@ -267,7 +264,6 @@ def sample_task_criteria_cfg() -> DictConfig:
 @pytest.fixture
 def sample_predicates_cfg() -> DictConfig:
     """A sample predicates definition."""
-
     return DictConfig(
         {
             "predicates": {
@@ -281,7 +277,6 @@ def sample_predicates_cfg() -> DictConfig:
 @pytest.fixture
 def sample_task_criteria_fp(sample_task_criteria_cfg: DictConfig, tmp_path: Path) -> Path:
     """A sample task criteria file path."""
-
     criteria_fp = tmp_path / "task_criteria.yaml"
     OmegaConf.save(sample_task_criteria_cfg, criteria_fp)
     return criteria_fp
@@ -290,7 +285,6 @@ def sample_task_criteria_fp(sample_task_criteria_cfg: DictConfig, tmp_path: Path
 @pytest.fixture
 def sample_predicates_fp(sample_predicates_cfg: DictConfig, tmp_path: Path) -> Path:
     """A sample predicates file path."""
-
     predicates_fp = tmp_path / "predicates.yaml"
     OmegaConf.save(sample_predicates_cfg, predicates_fp)
     return predicates_fp
@@ -308,7 +302,6 @@ def print_warnings(caplog: pytest.LogCaptureFixture):
 
     This is useful in doctests, where you want to show printed outputs for documentation and testing purposes.
     """
-
     n_current_records = len(caplog.records)
 
     with caplog.at_level("WARNING"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,21 @@ dependencies = [
   "hydra-core~=1.3.2",
   "MEDS-transforms>=0.6.7,<0.7",
   "flexible_schema>=0.1.1",
-  "pytimeparse",
+  "pytimeparse>=1.1.8",
 ]
 
 [dependency-groups]
+# Dev dependencies are pinned to specific versions to keep CI deterministic and remove
+# upgrade-induced flakiness. Use `uv lock --upgrade-package <name>` to bump.
 dev = [
-  "pre-commit<4", "ruff", "pytest", "pytest-cov", "pretty-print-directory", "hypothesis", "scikit-learn"
-] # Add your development (lint, test) dependencies here
+  "pre-commit==3.8.0",
+  "ruff==0.13.3",
+  "pytest==8.4.2",
+  "pytest-cov==7.0.0",
+  "pretty-print-directory==0.1.3",
+  "hypothesis==6.140.3",
+  "scikit-learn==1.7.2",
+]
 
 [tool.setuptools_scm]
 

--- a/src/MEDS_trajectory_evaluation/ACES_config_evaluation/label.py
+++ b/src/MEDS_trajectory_evaluation/ACES_config_evaluation/label.py
@@ -195,7 +195,6 @@ def label_trajectories(
           determine a label. ``null`` if the trajectory is not valid.
         - ``label`` (bool | null): The extracted label. ``null`` if not determinable.
     """
-
     subtree_anchor_realizations, predicates_df = get_predicates_and_anchor_realizations(
         trajectories, zero_shot_task_cfg
     )

--- a/src/MEDS_trajectory_evaluation/ACES_config_evaluation/task_config.py
+++ b/src/MEDS_trajectory_evaluation/ACES_config_evaluation/task_config.py
@@ -28,7 +28,6 @@ def validate_task_cfg(task_cfg: TaskExtractorConfig):
     Examples:
         >>> validate_task_cfg(sample_ACES_cfg)
     """
-
     for k in ("label_window", "index_timestamp_window"):
         val = getattr(task_cfg, k)
         if val is None:
@@ -66,7 +65,6 @@ def _strip_to_rel_windows(task_cfg: TaskExtractorConfig) -> ZeroShotTaskConfig:
     Returns:
         A zero-shot task configuration with only the relevant windows for zero-shot labeling.
     """
-
     prediction_time_window_name = task_cfg.index_timestamp_window
     prediction_time_window_cfg = task_cfg.windows[prediction_time_window_name]
     prediction_time_window = WindowNode(
@@ -122,7 +120,6 @@ def collapse_temporal_gap_windows(task_cfg: ZeroShotTaskConfig) -> ZeroShotTaskC
     Returns:
         The collapsed task configuration with the temporal gap windows maximally collapsed.
     """
-
     label_window_node = _resolve_node(task_cfg, root_node=WindowNode(task_cfg.label_window, "end"))
     root_to_label = list(task_cfg.window_nodes[label_window_node.node_name].node_path)
 
@@ -164,7 +161,6 @@ def remove_post_label_windows(task_cfg: ZeroShotTaskConfig) -> ZeroShotTaskConfi
     Returns:
         The modified task configuration with the post-label windows removed.
     """
-
     label_window_node = _resolve_node(task_cfg, root_node=WindowNode(task_cfg.label_window, "end"))
     label_window_node = task_cfg.window_nodes[label_window_node.node_name]
 
@@ -195,7 +191,6 @@ def convert_to_zero_shot(
     Returns:
         A zero-shot task configuration with the relevant windows and relationships for zero-shot labeling.
     """
-
     zero_shot_cfg = _strip_to_rel_windows(task_cfg)
 
     if labeler_cfg is None:
@@ -234,7 +229,6 @@ def resolve_zero_shot_task_cfg(task_cfg: DictConfig, labeler_cfg: DictConfig) ->
         FileNotFoundError: If the specified file paths do not exist.
         ValueError: If the task configuration is invalid or cannot be resolved.
     """
-
     orig_cfg = TaskExtractorConfig.load(task_cfg.criteria_fp, task_cfg.predicates_fp)
 
     validate_task_cfg(orig_cfg)

--- a/src/MEDS_trajectory_evaluation/ACES_config_evaluation/utils.py
+++ b/src/MEDS_trajectory_evaluation/ACES_config_evaluation/utils.py
@@ -52,6 +52,5 @@ def hash_based_seed(seed: int | None, worker: int | None) -> int:
         >>> hash_based_seed(None, None)
         3685662983
     """
-
     hash_str = f"{seed}_{worker}"
     return int(sha256(hash_str.encode()).hexdigest(), 16) % (2**32 - 1)

--- a/src/MEDS_trajectory_evaluation/aces_utils.py
+++ b/src/MEDS_trajectory_evaluation/aces_utils.py
@@ -416,7 +416,6 @@ def _resolve_node(
             ...
         ValueError: Exactly one of window_name or root_node must be provided.
     """
-
     if (window_name is None and root_node is None) or (window_name is not None and root_node is not None):
         raise ValueError("Exactly one of window_name or root_node must be provided.")
 
@@ -454,7 +453,6 @@ def get_MEDS_predicates(
         A DataFrame with the original subject and time columns plus one integer column per
         predicate, indicating how many times each predicate is satisfied at each row.
     """
-
     with tempfile.NamedTemporaryFile(suffix=".parquet") as data_fp:
         MEDS_df.write_parquet(data_fp.name, use_pyarrow=True)
         return get_predicates_df(task_cfg, DictConfig({"path": data_fp.name, "standard": "meds"}))

--- a/src/MEDS_trajectory_evaluation/schema.py
+++ b/src/MEDS_trajectory_evaluation/schema.py
@@ -1,7 +1,7 @@
 """Schema definition for generated MEDS trajectories.
 
-Extends the core MEDS data schema with a ``prediction_time`` column to associate generated events
-with the input data cutoff time used for generation.
+Extends the core MEDS data schema with a ``prediction_time`` column to associate generated events with the
+input data cutoff time used for generation.
 """
 
 import pyarrow as pa

--- a/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py
+++ b/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py
@@ -237,7 +237,6 @@ def _parse_resolution(resolution: str) -> timedelta:
         Uses :func:`pytimeparse.timeparse.parse` under the hood to support a
         range of short duration strings.
     """
-
     from pytimeparse import parse
 
     seconds = parse(resolution)
@@ -410,7 +409,6 @@ def get_grid(
     Raises:
         ValueError: If ``grid`` is a list containing non-timedelta elements.
     """
-
     match grid:
         case str() as resolution:
             return resolution_grid(ttes_df, resolution)

--- a/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/trajectory_AUC.py
+++ b/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/trajectory_AUC.py
@@ -46,7 +46,6 @@ def _normalize_predicates(predicates: PREDICATES_T | str | Path) -> PREDICATES_T
     Returns:
         The dictionary of plain predicate configurations.
     """
-
     if isinstance(predicates, str | Path):
         cfg = OmegaConf.load(str(predicates))
         predicates = cfg.get("predicates", cfg)
@@ -89,7 +88,6 @@ def temporal_auc_from_trajectory_files(
     Returns:
         A dataframe containing the temporal AUCs for each predicate.
     """
-
     preds = _normalize_predicates(predicates)
 
     if not isinstance(trajectories, str | Path):

--- a/tests/test_censoring.py
+++ b/tests/test_censoring.py
@@ -14,7 +14,6 @@ from MEDS_trajectory_evaluation.temporal_AUC_evaluation.temporal_AUCS import (
 
 def test_get_raw_tte_followup_time():
     """Test that get_raw_tte correctly calculates follow-up times."""
-
     # Create MEDS data with varying follow-up times
     MEDS_df = pl.DataFrame(
         {
@@ -71,7 +70,6 @@ def test_get_raw_tte_followup_time():
 
 def test_add_labels_censoring_aware():
     """Test censoring-aware labeling logic with comprehensive examples."""
-
     # Create test data with various censoring scenarios
     df = pl.DataFrame(
         {
@@ -124,7 +122,6 @@ def test_add_labels_censoring_aware():
 
 def test_temporal_aucs_censoring_exclusion():
     """Test that temporal_aucs properly excludes censored cases from AUC calculation."""
-
     # Create test data where censoring affects the outcome
     true_tte = pl.DataFrame(
         {
@@ -192,7 +189,6 @@ def test_temporal_aucs_censoring_exclusion():
 
 def test_censoring_edge_cases():
     """Test edge cases in censoring logic."""
-
     # Test with zero follow-up time
     df_zero_followup = pl.DataFrame(
         {
@@ -252,7 +248,6 @@ def test_censoring_edge_cases():
 
 def test_censoring_with_offset():
     """Test censoring logic with time offsets."""
-
     df = pl.DataFrame(
         {
             "subject_id": [1, 2],
@@ -274,7 +269,6 @@ def test_censoring_with_offset():
 
 def test_multiple_tasks_censoring():
     """Test censoring logic with multiple predicates/tasks."""
-
     df = pl.DataFrame(
         {
             "subject_id": [1, 2],

--- a/tests/test_task_config.py
+++ b/tests/test_task_config.py
@@ -12,7 +12,6 @@ from MEDS_trajectory_evaluation.ACES_config_evaluation.task_config import valida
 
 def test_validate_task_cfg_error_includes_tree_when_prediction_not_ancestor():
     """Ensures the validation error message contains the window tree when misconfigured."""
-
     task_cfg = TaskExtractorConfig(
         predicates={
             "trigger_pred": PlainPredicateConfig("TRIGGER"),

--- a/uv.lock
+++ b/uv.lock
@@ -342,18 +342,18 @@ requires-dist = [
     { name = "hydra-core", specifier = "~=1.3.2" },
     { name = "meds", specifier = "~=0.4.1" },
     { name = "meds-transforms", specifier = ">=0.6.7,<0.7" },
-    { name = "pytimeparse" },
+    { name = "pytimeparse", specifier = ">=1.1.8" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "hypothesis" },
-    { name = "pre-commit", specifier = "<4" },
-    { name = "pretty-print-directory" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-    { name = "scikit-learn" },
+    { name = "hypothesis", specifier = "==6.140.3" },
+    { name = "pre-commit", specifier = "==3.8.0" },
+    { name = "pretty-print-directory", specifier = "==0.1.3" },
+    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "ruff", specifier = "==0.13.3" },
+    { name = "scikit-learn", specifier = "==1.7.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Removes a long tail of CI flakiness driven by floating action versions and unpinned upstream deps. The immediate motivation was the codecov upload flake on the 3.13 leg of #40 (codecov-action v4 + GPG verify pipeline), but the same class of problem can hit any unpinned action / hook in the foreseeable future.

After this PR every CI build resolves to the same set of versions; future bumps are explicit (Dependabot or manual).

## Changes

### GitHub Actions (pinned to specific patches)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6.0.2` |
| `actions/setup-python` | `@v5` | `@v6.2.0` |
| `astral-sh/setup-uv` | `@v6` | `@v8.1.0` |
| `actions/upload-artifact` | `@v4` | `@v4.6.2` |
| `actions/download-artifact` | `@v4` | `@v4.3.0` |
| `codecov/codecov-action` | `@v4.0.1` | `@v5.5.4` |
| `sigstore/gh-action-sigstore-python` | `@v3.0.0` | `@v3.3.0` |
| `tj-actions/changed-files` | `@v46.0.5` | `@v47.0.6` |

`upload-artifact` / `download-artifact` are deliberately held at v4 — v5+ enforces immutable artifact names, which is fine for our pattern but I want to defer that change to its own PR with a CI dry-run. `pypa/gh-action-pypi-publish` is intentionally kept at `release/v1` per the publisher's [own recommendation](https://github.com/pypa/gh-action-pypi-publish#usage).

The codecov upload step also gets `fail_ci_if_error: false` so a transient codecov outage no longer reddens the matrix.

### `.pre-commit-config.yaml`

- Hook revs bumped: `pre-commit-hooks` v5→v6, `ruff-pre-commit` v0.11→v0.15, `docformatter` (org renamed `myint`→`PyCQA`) v1.7.5→v1.7.8, `shellcheck-py` v0.10.0.1→v0.11.0.1, `codespell` v2.4.1→v2.4.2, `nbstripout` 0.8.1→0.9.1.
- `mdformat` itself **held at 0.7.22** — `mdformat-tables==1.0.0` requires `mdformat<0.8.0`, so the plugin set caps the upper bound. Inline comment explains.
- All `mdformat` `additional_dependencies` pinned to specific versions (`mdformat-ruff==0.1.3`, `mdformat-gfm==1.0.0`, etc.).
- Ran `pre-commit autoupdate --freeze` so revs are now immutable commit SHAs with `# frozen: <tag>` annotations — addresses the case where a tag could be moved.

### `pyproject.toml`

- Added `pytimeparse>=1.1.8` floor.
- Pinned every dev dep with `==` (pre-commit, ruff, pytest, pytest-cov, pretty-print-directory, hypothesis, scikit-learn). Comment notes \`uv lock --upgrade-package <name>\` as the bump path.

### Mechanical reformat

The bumped `docformatter` enforces "no blank line between docstring and first statement" (PEP 257). Mechanical, no semantic changes; included here so we don't have a separate "stylistic noise" PR.

## Test plan

- [x] `uv run pre-commit run --all-files` clean
- [x] `uv run pytest` — 46 passed
- [ ] CI green (will watch)

## Notes for review

- No source-code logic changes other than docformatter blank-line stripping.
- shfmt and similar pre-commit-bound system tools don't apply here — none of our hooks shell out to a system binary that isn't bundled with its Python wheel.