### PR TITLE
Fix #33: wire include_history through temporal_auc_from_trajectory_files

### DIFF
--- a/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py
+++ b/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py
@@ -1052,6 +1052,20 @@ def temporal_aucs(
     else:
         exclude_set = set()
 
+    # Validate up front so the caller can't silently get unfiltered AUCs when they asked for
+    # `exclude_history`. The caller is responsible for producing the `history/<task>` columns
+    # (via `get_raw_tte(..., include_history=True)`); if any task in `exclude_set` is missing
+    # its history column we'd otherwise silently no-op the filter.
+    missing_history = [t for t in exclude_set if f"history/{t}" not in with_probs.columns]
+    if missing_history:
+        names = ", ".join(repr(t) for t in sorted(missing_history))
+        raise ValueError(
+            f"`exclude_history` requested for task(s) {{{names}}} but their `history/<task>` columns "
+            "are not present in `true_tte`. Pass `include_history=True` to `get_raw_tte` (or use "
+            "`temporal_auc_from_trajectory_files` which wires it through automatically) so the "
+            "history columns are computed before they are needed for filtering."
+        )
+
     dfs_by_task = []
     for task in tasks:
         df_task = with_probs
@@ -1060,7 +1074,7 @@ def temporal_aucs(
         if handle_censoring:
             df_task = df_task.filter(pl.col(f"label/{task}").is_not_null())
 
-        if task in exclude_set and f"history/{task}" in df_task.columns:
+        if task in exclude_set:
             df_task = df_task.filter(~pl.col(f"history/{task}"))
 
         dfs_by_task.append(

--- a/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/trajectory_AUC.py
+++ b/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/trajectory_AUC.py
@@ -105,7 +105,13 @@ def temporal_auc_from_trajectory_files(
 
     merged_pred = merge_pred_ttes(pred_dfs)
     index_df = pl.concat(index_dfs, how="vertical").unique(maintain_order=True)
-    true_tte = get_raw_tte(MEDS_df, index_df, preds, include_followup_time=True)
+    true_tte = get_raw_tte(
+        MEDS_df,
+        index_df,
+        preds,
+        include_history=bool(exclude_history),
+        include_followup_time=True,
+    )
 
     return temporal_aucs(
         true_tte,

--- a/tests/test_temporal_workflow.py
+++ b/tests/test_temporal_workflow.py
@@ -2,6 +2,7 @@ import math
 from datetime import UTC, datetime, timedelta
 
 import polars as pl
+import pytest
 from aces.config import PlainPredicateConfig
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
@@ -15,7 +16,119 @@ from MEDS_trajectory_evaluation.temporal_AUC_evaluation.get_ttes import (
 from MEDS_trajectory_evaluation.temporal_AUC_evaluation.temporal_AUCS import (
     temporal_aucs,
 )
+from MEDS_trajectory_evaluation.temporal_AUC_evaluation.trajectory_AUC import (
+    temporal_auc_from_trajectory_files,
+)
 from tests.helpers import _manual_auc
+
+
+def test_temporal_auc_from_trajectory_files_exclude_history_actually_filters(tmp_path):
+    """Regression test for https://github.com/mmcdermott/MEDS_trajectory_evaluation/issues/33.
+
+    Real-world scenario: predicting *first* diabetes diagnosis. Two of four admitted
+    patients had a prior dx — they should be excluded by `exclude_history=True`. Pre-fix,
+    `temporal_auc_from_trajectory_files` forwarded `exclude_history` to `temporal_aucs` but
+    never asked `get_raw_tte` to compute the `history/<task>` columns the filter depends on,
+    so the filter silently no-opped.
+    """
+    pt = datetime(2022, 4, 1, tzinfo=UTC)
+
+    # 4 patients, all admitted on 2022-04-01.
+    #   subj 1, 2: prior diabetes diagnosis — should be excluded.
+    #              For both, the model predicts perfectly.
+    #   subj 3, 4: no prior diabetes — should remain.
+    #              Subject 3: true post-admission event but predicted late (anti-correlated).
+    #              Subject 4: no true event but predicted an early event (anti-correlated).
+    MEDS_df = pl.DataFrame(
+        {
+            "subject_id": [1, 1, 2, 2, 3, 4],
+            "time": [
+                datetime(2021, 6, 1, tzinfo=UTC),  # subj 1: prior dx
+                datetime(2022, 4, 5, tzinfo=UTC),  # subj 1: future dx (4d post-pt)
+                datetime(2021, 8, 1, tzinfo=UTC),  # subj 2: prior dx
+                datetime(2022, 4, 6, tzinfo=UTC),  # subj 2: future dx (5d post-pt)
+                datetime(2022, 4, 4, tzinfo=UTC),  # subj 3: future dx only (3d post-pt)
+                datetime(2022, 5, 1, tzinfo=UTC),  # subj 4: lab only — no diabetes ever
+            ],
+            "code": [
+                "ICD10//E11.9",
+                "ICD10//E11.9",
+                "ICD10//E11.9",
+                "ICD10//E11.9",
+                "ICD10//E11.9",
+                "LAB_GLUCOSE",
+            ],
+        }
+    )
+
+    traj = pl.DataFrame(
+        {
+            "subject_id": [1, 1, 2, 2, 3, 3, 4, 4],
+            "prediction_time": [pt] * 8,
+            "time": [
+                pt,
+                datetime(2022, 4, 5, tzinfo=UTC),  # subj 1: prediction matches truth
+                pt,
+                datetime(2022, 4, 6, tzinfo=UTC),  # subj 2: prediction matches truth
+                pt,
+                datetime(2022, 5, 1, tzinfo=UTC),  # subj 3: predicts late (out of 10d window)
+                pt,
+                datetime(2022, 4, 5, tzinfo=UTC),  # subj 4: predicts in-window (wrong)
+            ],
+            "code": ["DUMMY", "ICD10//E11.9"] * 4,
+        }
+    )
+    traj.write_parquet(tmp_path / "traj_1.parquet")
+
+    predicates = {"diabetes": PlainPredicateConfig(code="ICD10//E11.9")}
+    grid = [timedelta(days=10)]
+
+    no_filter = temporal_auc_from_trajectory_files(
+        MEDS_df, tmp_path, predicates, duration_grid=grid, exclude_history=False
+    )
+    filtered = temporal_auc_from_trajectory_files(
+        MEDS_df, tmp_path, predicates, duration_grid=grid, exclude_history=True
+    )
+
+    # No-filter (all 4 subjects):
+    #   labels: subj 1 True, subj 2 True, subj 3 True (tte=3d <= 10d), subj 4 False
+    #   probs:  subj 1 = 1.0, subj 2 = 1.0, subj 3 = 0.0, subj 4 = 1.0
+    #   positives [1.0, 1.0, 0.0], negative [1.0] -> AUC = (1*0.5 + 1*0.5 + 0*0) / (3*1) = 1/3
+    assert math.isclose(no_filter["AUC/diabetes"][0], 1.0 / 3.0)
+
+    # exclude_history=True drops subj 1 and subj 2 (both had prior dx).
+    # Remaining: subj 3 (True, prob 0.0) and subj 4 (False, prob 1.0) -> anti-correlated -> AUC = 0.0
+    assert filtered["AUC/diabetes"][0] == 0.0
+
+
+def test_temporal_aucs_raises_when_exclude_history_lacks_history_columns():
+    """Regression test for #33: silent no-op surfaced as a clear error.
+
+    The buggy behavior was: `exclude_history=True` silently did nothing whenever the caller
+    forgot to also pass `include_history=True` to `get_raw_tte`. After the fix, that mistake
+    is loud — `temporal_aucs` raises with a message naming the missing tasks and pointing
+    the caller at the right knob.
+    """
+    pt = datetime(2022, 1, 1, tzinfo=UTC)
+    true_tte = pl.DataFrame(
+        {
+            "subject_id": [1, 2],
+            "prediction_time": [pt, pt],
+            "tte/A": [timedelta(days=2), None],
+            "max_followup_time": [timedelta(days=30), timedelta(days=30)],
+            # NB: no `history/A` column.
+        }
+    )
+    pred_ttes = pl.DataFrame(
+        {
+            "subject_id": [1, 2],
+            "prediction_time": [pt, pt],
+            "tte/A": [[timedelta(days=1)], [timedelta(days=20)]],
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"history/<task>"):
+        temporal_aucs(true_tte, pred_ttes, [timedelta(days=10)], exclude_history=True)
 
 
 def _duration_tds(min_days: int, max_days: int) -> st.SearchStrategy[timedelta]:


### PR DESCRIPTION
## Summary

Closes #33.

\`temporal_auc_from_trajectory_files\` accepted \`exclude_history\` and forwarded it to \`temporal_aucs\`, but never asked \`get_raw_tte\` to compute the \`history/<task>\` columns the filter depends on. \`temporal_aucs\`'s filter was gated on column presence, so it silently no-opped — users who asked for \`exclude_history=True\` got the same unfiltered AUCs as without the flag.

## Changes

1. \`temporal_auc_from_trajectory_files\` now passes \`include_history=bool(exclude_history)\` to \`get_raw_tte\`. History columns are computed exactly when needed.
2. \`temporal_aucs\` no longer treats "\`exclude_history\` requested but column missing" as a silent no-op — it raises a \`ValueError\` naming the missing tasks and pointing at the right knob. The use-site filter drops the column-presence guard.

## Test plan

- \`test_temporal_auc_from_trajectory_files_exclude_history_actually_filters\` — addresses the review note on PR #38: asserts both AUCs match their *exact* expected values (no-filter = 1/3, filtered = 0.0) for a realistic 4-patient diabetes-first-dx cohort. Not just \`!=\`.
- \`test_temporal_aucs_raises_when_exclude_history_lacks_history_columns\` — locks in the new raise-on-missing-history behavior at the \`temporal_aucs\` layer (the silent-noop path is gone).
- Full suite green (48 tests).

This PR subsumes #38: the failing-test PR's regression case is folded in here alongside the fix and upgraded to exact-value assertions per the review feedback. Once this merges, #38 can be closed.

Refs #30 (history flag itself, fixed in #40 — this PR builds on that)